### PR TITLE
Implement setProperty(), <script>. Fix syntax error.

### DIFF
--- a/class/Node.js
+++ b/class/Node.js
@@ -157,6 +157,11 @@ var Node = invent({
           if(key == 'cssText') {
             return mapToCss(objectToMap(target))
           }
+          if(key == 'setProperty') {
+            return function(propertyName, value, priority) {
+              Reflect.set(target, propertyName, value)
+            }
+          }
           key = camelCase(key)
           if(!target[key]) return ''
           return Reflect.get(target, key)

--- a/dom.js
+++ b/dom.js
@@ -41,6 +41,32 @@ var HTMLLinkElement  = invent({
   }
 })
 
+var HTMLScriptElement  = invent({
+  name: 'HTMLScriptElement',
+  create: function() {
+    Node.call(this, 'script')
+  },
+  inherit: Node,
+  props: {
+    src: {
+      get: function() {
+        return this.attrs.get('src')
+      },
+      set: function(val) {
+        this.attrs.set('src', val)
+      }
+    },
+    type: {
+      get: function() {
+        return this.attrs.get('type')
+      },
+      set: function(val) {
+        this.attrs.set('type', val)
+      }
+    },
+  }
+})
+
 var HTMLImageElement  = invent({
   name: 'HTMLImageElement',
   create: function(){
@@ -229,6 +255,8 @@ var Document = invent({
           return new HTMLImageElement({ownerDocument: this})
         case 'link':
           return new HTMLLinkElement({ownerDocument: this})
+        case 'script':
+          return new HTMLScriptElement({ownerDocument: this})
         default:
           return new SVGElement(name, {ownerDocument: this})
       }
@@ -292,6 +320,7 @@ extend(Window, {
   SVGMatrix: SVGMatrix,
   SVGPoint: SVGPoint,
   HTMLLinkElement: HTMLLinkElement,
+  HTMLScriptElement: HTMLScriptElement,
   Image: HTMLImageElement,
   HTMLImageElement: HTMLImageElement,
   setTimeout: setTimeout,

--- a/utils/pathUtils.js
+++ b/utils/pathUtils.js
@@ -268,7 +268,7 @@ var Arc = invent({
 
       return ret[0].length() + ret[1].length()
     },
-    splitAt: function(t) 
+    splitAt: function(t) {
       var absDelta = Math.abs(this.delta)
       var delta1 = absDelta * t
       var delta2 = absDelta * (1-t)


### PR DESCRIPTION
Hi, this implements CSSStyleDeclaration.setProperty() and HTMLScriptElement; and it fixes the splitAt() function.