### PR TITLE
text.bbox - parse fontSize to be a number

### DIFF
--- a/utils/textUtils.js
+++ b/utils/textUtils.js
@@ -34,6 +34,7 @@ const bbox = function(text, x, y, details) {
   var fontHeight = font.ascent - font.descent
   var lineHeight = fontHeight > font.unitsPerEm ? fontHeight : fontHeight + font.lineGap
 
+  fontSize = parseFloat(fontSize)
   var height = lineHeight/font.unitsPerEm * fontSize
   var width = font.layout(text).glyphs.reduce((last, curr) => last + curr.advanceWidth, 0) / font.unitsPerEm * fontSize
 


### PR DESCRIPTION
Hello, I'm not sure should it be done this way... but on my app on node.js function text.bbox() is not working without this change (height comes as NaN). Let me know if threre is better way...