### PR TITLE
add class references to Window, fix typos

### DIFF
--- a/class/Node.js
+++ b/class/Node.js
@@ -254,11 +254,11 @@ var Node = invent({
       this.childNodes.splice(index, 1)
       return node
     },
-    replacedNode: function(newChild, oldChild) {
+    replaceChild: function(newChild, oldChild) {
       newChild.parentNode && newChild.parentNode.removeChild(newChild)
 
       var before = oldChild.nextSibling
-      this.remove(oldChild)
+      this.removeChild(oldChild)
       this.insertBefore(newChild, before)
       return oldChild
     },

--- a/dom.js
+++ b/dom.js
@@ -312,6 +312,8 @@ var Window = invent({
 
 
 extend(Window, {
+  Window: Window,
+  DocumentFragment: DocumentFragment,
   Node: Node,
   Text: TextNode,
   Element: SVGElement,

--- a/dom.js
+++ b/dom.js
@@ -313,7 +313,8 @@ var Window = invent({
 
 extend(Window, {
   Node: Node,
-  TextNode: TextNode,
+  Text: TextNode,
+  Element: SVGElement,
   SVGElement: SVGElement,
   CustomEvent: CustomEvent,
   Event: Event,


### PR DESCRIPTION
Hi, here is another little pull request: it fixes two typos in `replaceChild()` and adds the classes `Window`, `Document`, `DocumentFragment`, `Element`, and `Text` to `Window`.