### PR TITLE
 added escaping html elements on doc. creation.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -6,6 +6,9 @@ const {SVGElement, DocumentFragment, Node, TextNode, Comment} = require('./class
 const sizeOf = require('image-size')
 const path = require('path')
 const fontkit = require('fontkit')
+const { htmlEntities } = require('./utils/strUtils')
+
+
 
 var HTMLLinkElement  = invent({
   name: 'HTMLLinkElement',
@@ -262,10 +265,10 @@ var Document = invent({
       }
     },
     createTextNode: function(text) {
-      return new TextNode('#text', {data:text, ownerDocument: this})
+      return new TextNode('#text', {data: htmlEntities(text), ownerDocument: this})
     },
     createComment: function(text) {
-      return new Comment('#comment', {data:text, ownerDocument: this})
+      return new Comment('#comment', {data: text, ownerDocument: this})
     },
     createAttribute: function(name) {
       return new AttributeNode(name, {ownerDocument: this})

--- a/test/002_escaped-text.js
+++ b/test/002_escaped-text.js
@@ -1,0 +1,12 @@
+
+import svgdom from '../dom'
+import assert from 'assert'
+
+describe("escaped-text",() => {
+    it(" svg with text contain htl elements should be printable ", ()=>{
+        var svgDoc = new svgdom.constructor ().document;
+        var textNode = svgDoc.createTextNode("A<B");
+        var html = textNode.innerHTML.toString();
+        assert( html.indexOf("<") == -1 );
+    });
+});


### PR DESCRIPTION
dom.createTextNode should escape HTML entities in text, otherwise illegal svg() will be produced in innerHtml.
