### PR TITLE
fix #62: Element.style.setProperty()

### DIFF
--- a/main-require.cjs
+++ b/main-require.cjs
@@ -794,7 +794,7 @@ const getStyleProxy = (node) => {
 
       if (key === 'setProperty') {
         return function (propertyName, value = '', priority = '') {
-          this.style[propertyName] = value + priority ? ` !${priority}` : ''
+          node.style[propertyName] = value + (priority ? ` !${priority}` : '')
         }
       }
 

--- a/src/dom/Element.js
+++ b/src/dom/Element.js
@@ -25,7 +25,7 @@ const getStyleProxy = (node) => {
 
       if (key === 'setProperty') {
         return function (propertyName, value = '', priority = '') {
-          this.style[propertyName] = value + priority ? ` !${priority}` : ''
+          node.style[propertyName] = value + (priority ? ` !${priority}` : '')
         }
       }
 

--- a/test/001-svg-dom.js
+++ b/test/001-svg-dom.js
@@ -1,9 +1,9 @@
 /* global describe, it, before, after, beforeEach */
 
-import puppeteer from 'puppeteer'
+// import puppeteer from 'puppeteer'
 import assert from 'assert'
 // import { DOMParser, XMLSerializer, DOMImplementation } from 'xmldom'
-import svgdom from '../dom'
+import { createSVGDocument } from '..'
 // import fs from 'fs'
 
 // var svgString
@@ -167,7 +167,7 @@ describe('svg document', () => {
 
       await page.evaluate(prepare)
     } else {
-      svgDoc = new svgdom.constructor().document
+      svgDoc = createSVGDocument()
       svgRoot = svgDoc.documentElement
 
       prepare()
@@ -183,7 +183,7 @@ describe('svg document', () => {
     assert(svgDoc.createComment('xxx'))
   })
 
-  wrappedIt('should have ownerSVGElement property for nodes', () => {
+  wrappedIt.skip('should have ownerSVGElement property for nodes', () => {
     // this will not work with documents, embedded into html
     // but should work with svg docs as media <object>
     if (svgDoc.documentElement.nodeName === 'svg') { assert(svgRoot.ownerSVGElement) }
@@ -333,6 +333,10 @@ describe('svg document', () => {
     connector.style.fill = 'black'
 
     assert(connector.getAttribute('style').match(/^fill:\s*black\b/))
+
+    connector.style.setProperty('color', 'green')
+
+    assert(connector.getAttribute('style').match(/color:\s*green\b/))
 
     assert([].some.call(connector.attributes, attr => attr.nodeName === 'style'))
   })

--- a/test/002_escaped-text.js
+++ b/test/002_escaped-text.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-import svgdom from '../dom'
+import { createSVGDocument } from '..'
 import assert from 'assert'
 
 describe('escaped-text', () => {
   it(' svg with text contain html elements should be printable ', () => {
-    var svgDoc = new svgdom.constructor().document
+    var svgDoc = createSVGDocument()
     var textNode = svgDoc.createTextNode('A<B')
     var html = textNode.innerHTML.toString()
     assert(html.indexOf('<') === -1)

--- a/test/003-unsescape-bbox.js
+++ b/test/003-unsescape-bbox.js
@@ -1,12 +1,12 @@
 /* global describe, it */
 
-import svgdom from '../dom'
+import { createSVGDocument } from '..'
 import assert from 'assert'
-const getPointCloud = require('../utils/bboxUtils')
+const getPointCloud = require('../src/utils/bboxUtils')
 
 describe('unescape-bbox', () => {
   it(" bbox('<').x should be less then bbox('WW') ", () => {
-    var svgDoc = new svgdom.constructor().document
+    var svgDoc = createSVGDocument()
     var svgRoot = svgDoc.documentElement
     var textLt = svgDoc.createElement('text')
     textLt.textContent = '<'

--- a/test/004-circle-length.js
+++ b/test/004-circle-length.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-import svgdom from '../dom'
+import { createSVGWindow, createSVGDocument } from '..'
 import assert from 'assert'
 
-const document = svgdom.document
+const document = createSVGDocument()
 const { SVG, registerWindow } = require('@svgdotjs/svg.js')
-registerWindow(svgdom, svgdom.document)
+registerWindow(createSVGWindow(), document)
 
 describe('circle-length', () => {
   it('circumference of circle of radius 49.5 should be close to 99*Math.PI', () => {


### PR DESCRIPTION
This fixes Element.style.setProperty() and kind of makes the unit tests run again. Half of them are still failing, but I added one for `setProperty()`  :-}

The `ownerSVGElement` access results in an infinite loop, btw, so I disabled that test.