### PR TITLE
Fix removeAttributeNS to called namespaced getAttributeNodeNS

### DIFF
--- a/src/dom/Element.js
+++ b/src/dom/Element.js
@@ -157,8 +157,8 @@ export class Element extends Node {
   }
 
   // call is: d.removeAttributeNS('http://www.mozilla.org/ns/specialspace', 'align', 'center');
-  removeAttributeNS (ns, name) {
-    const attr = this.getAttributeNode(ns, name)
+  removeAttributeNS (ns, localName) {
+    const attr = this.getAttributeNodeNS(ns, localName)
     if (attr) {
       this.removeAttributeNode(attr)
     }


### PR DESCRIPTION
`removeAttributeNS (ns, name)` seems to call through to the single-argument `getAttributeNode (qualifiedName)`, i.e. it tries to find a node with a name of the namespace. This PR fixes that by calling through to the namespace-aware `getAttributeNodeNS (ns, localName)` instead.