### PR TITLE
Window.getComputedStyle.getPropertyValue bug fix

### DIFF
--- a/src/dom/Window.js
+++ b/src/dom/Window.js
@@ -46,13 +46,14 @@ export class Window extends EventTarget {
       // but good enough for svg.js
       getPropertyValue (attr) {
         let value
+        let cur = node
 
         do {
-          value = node.style[attr] || node.getAttribute(attr)
+          value = cur.style[attr] || cur.getAttribute(attr)
         } while (
           value == null
-          && (node = node.parentNode)
-          && node.nodeType === 1
+          && (cur = cur.parentNode)
+          && cur.nodeType === 1
         )
 
         return value || defaults[camelCase(attr)] || null

--- a/src/dom/svg/SVGElement.js
+++ b/src/dom/svg/SVGElement.js
@@ -1,23 +1,23 @@
-import {Element} from '../Element.js';
+import { Element } from '../Element.js'
 export class SVGElement extends Element {
-  get ownerSVGElement() {
-    let parent;
-    while ((parent = this.parentNode)) {
+  get ownerSVGElement () {
+    let parent = this
+    while ((parent = parent.parentNode)) {
       if ('svg' == parent.nodeName) {
-        return parent;
+        return parent
       }
     }
-    return null;
+    return null
   }
 
-  get viewportElement() {
-    let parent;
-    while ((parent = this.parentNode)) {
+  get viewportElement () {
+    let parent = this
+    while ((parent = parent.parentNode)) {
       // TODO: and others
-      if (['svg', 'symbol'].includes(parent.nodeName)) {
-        return parent;
+      if ([ 'svg', 'symbol' ].includes(parent.nodeName)) {
+        return parent
       }
     }
-    return null;
+    return null
   }
 }

--- a/src/dom/svg/SVGElement.js
+++ b/src/dom/svg/SVGElement.js
@@ -1,25 +1,23 @@
-import { Element } from '../Element.js'
+import {Element} from '../Element.js';
 export class SVGElement extends Element {
-  get ownerSVGElement () {
-    let owner = null
-    let parent = this
-    while ((parent = parent.parentNode)) {
-      if (parent.nodeName === 'svg') {
-        owner = parent
+  get ownerSVGElement() {
+    let parent;
+    while ((parent = this.parentNode)) {
+      if ('svg' == parent.nodeName) {
+        return parent;
       }
     }
-    return owner
+    return null;
   }
 
-  get viewportElement () {
-    let owner = null
-    let parent
+  get viewportElement() {
+    let parent;
     while ((parent = this.parentNode)) {
       // TODO: and others
-      if ([ 'svg', 'symbol' ].contains(parent.nodeName)) {
-        owner = parent
+      if (['svg', 'symbol'].includes(parent.nodeName)) {
+        return parent;
       }
     }
-    return owner
+    return null;
   }
 }


### PR DESCRIPTION
In the object returned by `Window.getComputedStyle` its `getPropertyValue` method has a bug
It puts the element in a closure variable `node`.
When you update the variable, the value will remain.
Try this.
```
const style = window.getComputedStyle(element);
style.getPropertyValue('fill');
style.getPropertyValue('fill'); // <-- TypeError: Cannot read property 'fill' of undefined
```
Because now the `node` variable is Document object with no style property
