### PR TITLE
Fix fontkit import

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/svgdotjs/svgdom#readme",
   "dependencies": {
-    "fontkit": "^1.8.1",
+    "fontkit": "^2.0.2",
     "image-size": "^1.0.2",
     "sax": "^1.2.4"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import fontkit from 'fontkit'
+import * as fontkit from 'fontkit'
 
 const _config = {}
 const fonts = {}

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import fontkit from 'fontkit'
+import * as fontkit from 'fontkit'
 import * as defaults from './defaults.js'
 import { Box, NoBox } from '../other/Box.js'
 import { getConfig, getFonts } from '../config.js'


### PR DESCRIPTION
Update `fontkit` dependency to 2.0.2 and replace the default import of `fontkit` with a glob.