### PR TITLE
Fix conditional export for CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./main-module.js",
   "exports": {
     "import": "./main-module.js",
-    "require": "./main-module.js"
+    "require": "./dist/main-require.cjs"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Hi folks, 
I have a problem using this package in the CommonJS environment in my company.

According to the nodejs specification [1], the 'require' key should be the target for CommonJS.

Therefore, change the target that is already built for the 'require' key for conditional exports.


[1] https://nodejs.org/api/packages.html#conditional-exports