### PR TITLE
Ensure that fontSize is always a number

### DIFF
--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -13,7 +13,7 @@ export const textBBox = function (text, x, y, details) {
 
   const families = (details.fontFamily || defaults.fontFamily).split(/\s*,\s*/)
   const fontMap = Object.assign({}, defaults.fontFamilyMappings, config.fontFamilyMappings)
-  const fontSize = details.fontSize || defaults.fontSize
+  const fontSize = Number(`${details.fontSize}`.replace(/\D/g, '') || defaults.fontSize);
   const fontDir = config.fontDir || defaults.fontDir
   let fontFamily
   let font


### PR DESCRIPTION
When calculating the bounding box of a `text` node in nodejs, the result returned is often NaN.
This change ensures that the fontSize is always a number, for example by removing the `px` suffix.

There is a related pull request created a few years ago: https://github.com/svgdotjs/svgdom/pull/23