### PR TITLE
update image-size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "svgdom",
-  "version": "0.1.15",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svgdom",
-      "version": "0.1.15",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "fontkit": "^2.0.2",
-        "image-size": "^1.0.2",
+        "image-size": "^1.2.1",
         "sax": "^1.2.4"
       },
       "devDependencies": {
@@ -2197,9 +2197,10 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -2207,7 +2208,7 @@
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/svgdotjs/svgdom#readme",
   "dependencies": {
     "fontkit": "^2.0.2",
-    "image-size": "^1.0.2",
+    "image-size": "^1.2.1",
     "sax": "^1.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The `image-size` package has [a dependabot security alert](https://github.com/altano/npm-packages/security/dependabot/142). The latest version, v1.2.1, is fixed. Updating this package to use the latest version to fix the security issue.