### PR TITLE
Add removeProperty support for Element

### DIFF
--- a/src/dom/Element.js
+++ b/src/dom/Element.js
@@ -72,6 +72,15 @@ const getStyleProxy = (node) => {
         }
       }
 
+      if (key === 'removeProperty') {
+        return function (propertyName) {
+          const styles = node.getAttribute('style') || ''
+          const styleMap = cssToMap(styles)
+          styleMap.delete(decamelize(propertyName))
+          node.setAttribute('style', mapToCss(styleMap))
+        }
+      }
+
       if (key === 'getPropertyValue') {
         return function (propertyName) {
           return node.style[propertyName] ?? ''


### PR DESCRIPTION
Adds support for `removeProperty` for `Element`'s CSSStyleDeclaration. Required to support headless mermaid rendering in certain cases.