### PR TITLE
Fix text bbox calculation with em units and dx/dy positioning

### DIFF
--- a/src/utils/bboxUtils.js
+++ b/src/utils/bboxUtils.js
@@ -176,7 +176,7 @@ const getPositionDetailsFor = (node, pos, dx, dy, boxes) => {
     // if it is more than one dx/dy single letters are moved by the amount (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dx)
     if (dy.length || dx.length) {
       for (;j < jl; j++) {
-        // Apply dx/dy shift before calculating bbox (per SVG spec, dx/dy apply to current glyph)
+        // Apply dx/dy shift before calculating bbox (https://svgwg.org/svg2-draft/text.html#TextElementDXAttribute)
         pos.x += dx.shift() || 0
         pos.y += dy.shift() || 0
 

--- a/src/utils/bboxUtils.js
+++ b/src/utils/bboxUtils.js
@@ -5,6 +5,14 @@ import { NoBox } from '../other/Box.js'
 import { NodeIterator } from './NodeIterator.js'
 import { NodeFilter } from '../dom/NodeFilter.js'
 
+// Parse CSS length value, converting em units to pixels
+const parseLength = (value, fontSize) => {
+  const num = parseFloat(value)
+  if (isNaN(num)) return NaN
+  if (/em$/i.test(value)) return num * fontSize
+  return num
+}
+
 const applyTransformation = (segments, node, applyTransformations) => {
   if (node.matrixify && applyTransformations) {
     return segments.transform(node.matrixify())
@@ -142,14 +150,16 @@ const isNotEmptyBox = box => box.x !== 0 || box.y !== 0 || box.width !== 0 || bo
 // TODO: Break this into two functions?
 const getPositionDetailsFor = (node, pos, dx, dy, boxes) => {
   if (node.nodeType === node.ELEMENT_NODE) {
-    const x = parseFloat(node.getAttribute('x'))
-    const y = parseFloat(node.getAttribute('y'))
+    const fontSize = parseFloat(getFontDetails(node).fontSize) || 16
+
+    const x = parseLength(node.getAttribute('x'), fontSize)
+    const y = parseLength(node.getAttribute('y'), fontSize)
 
     pos.x = isNaN(x) ? pos.x : x
     pos.y = isNaN(y) ? pos.y : y
 
-    const dx0 = (node.getAttribute('dx') || '').split(regex.delimiter).filter(num => num !== '').map(parseFloat)
-    const dy0 = (node.getAttribute('dy') || '').split(regex.delimiter).filter(num => num !== '').map(parseFloat)
+    const dx0 = (node.getAttribute('dx') || '').split(regex.delimiter).filter(num => num !== '').map(v => parseLength(v, fontSize))
+    const dy0 = (node.getAttribute('dy') || '').split(regex.delimiter).filter(num => num !== '').map(v => parseLength(v, fontSize))
 
     // TODO: eventually replace only as much values as we have text chars (node.textContent.length) because we could end up adding to much
     // replace initial values with node values if present
@@ -166,12 +176,12 @@ const getPositionDetailsFor = (node, pos, dx, dy, boxes) => {
     // if it is more than one dx/dy single letters are moved by the amount (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dx)
     if (dy.length || dx.length) {
       for (;j < jl; j++) {
-        // Calculate a box for a single letter
-        boxes.push(textUtils.textBBox(data.substr(j, 1), pos.x, pos.y, details))
-
-        // Add the next position to current one
+        // Apply dx/dy shift before calculating bbox (per SVG spec, dx/dy apply to current glyph)
         pos.x += dx.shift() || 0
         pos.y += dy.shift() || 0
+
+        // Calculate a box for a single letter
+        boxes.push(textUtils.textBBox(data.substr(j, 1), pos.x, pos.y, details))
 
         if (!dy.length && !dx.length) break
       }

--- a/test/010-bbox-text.js
+++ b/test/010-bbox-text.js
@@ -17,4 +17,37 @@ describe('bbox-text', () => {
       assert(!isNaN(bboxText[property]));
     })
   })
+
+  it("converts em units in dy attribute", () => {
+    const svgDoc = createSVGWindow().document
+    const text = svgDoc.createElementNS('http://www.w3.org/2000/svg', 'text')
+    text.style.fontSize = '16px'
+    const tspan = svgDoc.createElementNS('http://www.w3.org/2000/svg', 'tspan')
+    tspan.setAttribute('dy', '1em')
+    tspan.textContent = 'x'
+    text.appendChild(tspan)
+    svgDoc.documentElement.appendChild(text)
+
+    // dy=1em at 16px should shift by 16px, not 1px
+    assert(text.getBBox().y > -5)
+  })
+
+  it("applies dy before calculating bbox", () => {
+    const svgDoc = createSVGWindow().document
+    const text = svgDoc.createElementNS('http://www.w3.org/2000/svg', 'text')
+    text.style.fontSize = '16px'
+    text.setAttribute('y', '20')
+    text.textContent = 'x'
+    svgDoc.documentElement.appendChild(text)
+
+    const text2 = svgDoc.createElementNS('http://www.w3.org/2000/svg', 'text')
+    text2.style.fontSize = '16px'
+    const tspan = svgDoc.createElementNS('http://www.w3.org/2000/svg', 'tspan')
+    tspan.setAttribute('dy', '20')
+    tspan.textContent = 'x'
+    text2.appendChild(tspan)
+    svgDoc.documentElement.appendChild(text2)
+
+    assert(Math.abs(text.getBBox().y - text2.getBBox().y) < 1)
+  })
 })


### PR DESCRIPTION
## Problem

`getBBox()` returns incorrect values for text elements when:
1. `x`, `y`, `dx`, or `dy` attributes use `em` units (e.g., `dy="1.1em"`)
2. `dx`/`dy` values are applied after calculating the first glyph's bbox instead of before

This causes ~15px positioning errors in libraries like mermaid that use em-based text positioning.

## Root Cause

In `src/utils/bboxUtils.js`:

1. **No em unit handling**: `parseFloat("1.1em")` returns `1.1` instead of converting to pixels (`17.6px` at 16px font-size)

2. **Wrong dx/dy application order**: Per SVG spec, `dx`/`dy` values apply to the current glyph, but the code calculates bbox first, then applies the shift

## Fix

1. Added `parseLength()` helper that converts em units to pixels using the element's font-size
2. Reordered the loop to apply dx/dy shifts before calculating each glyph's bbox

## Notes

This is different from issue #122 (unit conversion for document dimensions like inches). Em units are relative to font-size which is available, unlike display DPI.